### PR TITLE
Fix critical accuracy issues: calibration, regime, class imbalance

### DIFF
--- a/lib/data/features.py
+++ b/lib/data/features.py
@@ -108,21 +108,23 @@ def engineer_features(data: pd.DataFrame, config: dict, log) -> pd.DataFrame:
     entropy_main = data["entropy"].values
 
     if entropy_windows:
-        entropy_arr = data[[f"entropy_{w}" for w in entropy_windows]].values  # (n, k)
         if low_thr is None or high_thr is None:
-            # Per-row percentiles across entropy scales — matches original per-row behavior
-            low_thr_arr = np.percentile(entropy_arr, 33, axis=1)
-            high_thr_arr = np.percentile(entropy_arr, 66, axis=1)
+            # Global percentiles of primary entropy across all rows — gives
+            # ~33% of draws in each regime.  The previous per-row percentile
+            # approach (axis=1 across only 3 windows) caused the middle
+            # window to almost always land in regime 1.
+            low_thr_val = np.percentile(entropy_main, 33)
+            high_thr_val = np.percentile(entropy_main, 66)
         else:
-            low_thr_arr = np.full(n, low_thr)
-            high_thr_arr = np.full(n, high_thr)
+            low_thr_val = low_thr
+            high_thr_val = high_thr
     else:
-        low_thr_arr = np.zeros(n)
-        high_thr_arr = np.zeros(n)
+        low_thr_val = 0.0
+        high_thr_val = 0.0
 
     data["regime"] = np.where(
-        entropy_main < low_thr_arr, 0,
-        np.where(entropy_main > high_thr_arr, 2, 1)
+        entropy_main < low_thr_val, 0,
+        np.where(entropy_main > high_thr_val, 2, 1)
     )
 
     # === 9. Global frequency per ball (vectorized lookup) ===

--- a/lib/models/builder.py
+++ b/lib/models/builder.py
@@ -34,6 +34,7 @@ def build_model(hgbc_params=None, calibration_cv=2):
         min_samples_split=20,
         min_samples_leaf=20,
         max_features="sqrt",
+        class_weight="balanced",
         random_state=42,
         n_jobs=-1,
     )
@@ -47,6 +48,7 @@ def build_model(hgbc_params=None, calibration_cv=2):
         max_depth=4,
         min_samples_leaf=50,
         learning_rate=0.05,
+        class_weight="balanced",
         random_state=42,
     )
     if hgbc_params:

--- a/lib/models/predictor.py
+++ b/lib/models/predictor.py
@@ -77,12 +77,14 @@ def _sample_from_proba(model, input_vector, temperature=1.0, smoothing=0.0,
 # ------------------------------------------------------------
 def _calibrate_temperature(model, x_cal, y_cal):
     """
-    Find the temperature T in [1.0, 8.0] that minimises negative log-likelihood
+    Find the temperature T in [0.3, 5.0] that minimises negative log-likelihood
     on the held-out calibration set — the standard 'temperature scaling' form
     of Platt calibration.  T > 1 means the model was overconfident (flatten
-    the distribution).  We only search T >= 1.0 because sharpening (T < 1)
-    would undo smoothing and force near-deterministic predictions that fail
-    the statistical diversity filters.
+    the distribution); T < 1 sharpens toward the model's best guesses, which
+    is appropriate for multi-class problems where raw probabilities are already
+    quite diffuse across many classes.  Prediction-time smoothing (uniform +
+    recency blending) separately ensures diversity, so sharpening the base
+    calibration won't cause mode collapse.
 
     Returns the optimal temperature as a float (defaults to 1.0 if calibration
     data is too small or labels don't overlap with training classes).
@@ -104,7 +106,7 @@ def _calibrate_temperature(model, x_cal, y_cal):
     probas = probas[valid_mask]                 # select valid rows positionally
 
     best_temp, best_nll = 1.0, float("inf")
-    for temp in np.linspace(1.0, 8.0, 71):     # ~0.1-step grid, T >= 1.0 only
+    for temp in np.linspace(0.3, 5.0, 95):     # ~0.05-step grid, includes T < 1.0
         scaled = np.power(probas + 1e-12, 1.0 / temp)
         scaled /= scaled.sum(axis=1, keepdims=True)
         nll = -np.log(scaled[np.arange(len(true_idx)), true_idx] + 1e-12).mean()


### PR DESCRIPTION
## Summary
- **Temperature calibration**: Expand search range from [1.0, 8.0] to [0.3, 5.0] — the old range always returned T=1.0 for multi-class problems, making calibration a no-op. Models now calibrate to 0.7–0.9, sharpening toward their best guesses.
- **Regime classification**: Switch from per-row percentiles (axis=1 across 3 entropy windows) to global percentiles across all rows. The old approach mathematically guaranteed regime=1 for nearly every draw. Now ~33% per regime.
- **Class imbalance**: Add `class_weight='balanced'` to both RF and HGBC. With 46+ classes per ball position, unweighted models were biased toward common numbers.

## Test plan
- [x] All 59 unit tests pass (93% coverage)
- [x] E2E pipeline: `python lottery.py NJ_Pick6 --dry-run --force-retrain` completes successfully
- [x] Verified calibrated temperatures are now non-trivial (0.7–0.9 vs all 1.0)
- [x] Verified regime distribution is ~33/33/34% across history (was ~100% regime 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)