### PR TITLE
Fix automerge: use git config signing instead of -S flag

### DIFF
--- a/lib/data/github.py
+++ b/lib/data/github.py
@@ -42,11 +42,8 @@ class GitHubAutoMerge:
             # Initialize GitPython repository object
             self.repo = git.Repo(self.repo_path)
 
-            # Configure commit signing from environment variables
-            self.signing_key = os.getenv("GIT_SIGNING_KEY")
-            self.sign_commits = os.getenv("GIT_SIGN_COMMITS", "false").lower() == "true"
-            if self.sign_commits:
-                print(f"Commit signing enabled.")
+            # Commit signing is now handled entirely by git config
+            # (commit.gpgsign + gpg.format). No env vars needed.
 
             # Initialize PyGithub client
             self.g = Github(self.github_pat)
@@ -118,12 +115,11 @@ class GitHubAutoMerge:
             new_branch = self.repo.create_head(new_branch_name, commit=remote_main.commit)
             new_branch.checkout()
 
-            # Commit with signing
-            # self.repo.index.commit(commit_message)  # Causes unverified commits
-            if self.sign_commits and self.signing_key:
-                self.repo.git.commit('-m', commit_message, '-S')
-            else:
-                self.repo.git.commit('-m', commit_message)
+            # Commit — signing is handled by git config (commit.gpgsign).
+            # Avoid passing -S explicitly: it forces GPG-style signing and
+            # breaks when gpg.format=ssh (SSH key signing), which uses a
+            # different temp-file path that the -S flag doesn't respect.
+            self.repo.git.commit('-m', commit_message)
 
             print(f"Committed changes on branch '{new_branch_name}'.")
 


### PR DESCRIPTION
## Summary
- Remove explicit `-S` flag from automerge commits — it forces GPG-style signing which breaks on systems using SSH key signing (`gpg.format=ssh`)
- The git config `commit.gpgsign=true` already handles signing correctly for both GPG and SSH formats
- Remove unused `GIT_SIGNING_KEY` / `GIT_SIGN_COMMITS` env var handling (now redundant)

Root cause: the systemd service was failing with `Cannot open /tmp/.git_signing_buffer_tmp* for signing: Permission denied` because `-S` invokes the GPG signing path, not SSH.

## Test plan
- [x] All 59 unit tests pass
- [x] Verified `commit.gpgsign=true` + `gpg.format=ssh` handles signing without `-S`

🤖 Generated with [Claude Code](https://claude.com/claude-code)