### PR TITLE
High-priority accuracy: pruning, temporal features, ensemble diversity

### DIFF
--- a/lib/data/features.py
+++ b/lib/data/features.py
@@ -45,12 +45,13 @@ def engineer_features(data: pd.DataFrame, config: dict, log) -> pd.DataFrame:
             data[f"{col}_lag{lag}_appeared"] = (lagged[col] == data[col]).astype(int)
 
     # === 3. Recent count features (vectorized via rolling one-hot) ===
+    recent_count_windows = config.get("recent_count_windows", [5, 10, 20, 50])
     for col in ball_cols_main:
         # shift(1) excludes the current row from its own window count
         shifted_dummies = pd.get_dummies(data[col]).shift(1).fillna(0)
         col_idx_map = {v: i for i, v in enumerate(shifted_dummies.columns)}
         row_col_indices = data[col].map(col_idx_map).fillna(0).astype(int).values
-        for window in [5, 10, 20]:
+        for window in recent_count_windows:
             rolling_w = shifted_dummies.rolling(window, min_periods=1).sum()
             data[f"{col}_recent_count_{window}"] = rolling_w.values[
                 np.arange(n), row_col_indices
@@ -66,6 +67,13 @@ def engineer_features(data: pd.DataFrame, config: dict, log) -> pd.DataFrame:
     rolling_sum = data["sum"].rolling(11, min_periods=1)
     rolling_std = rolling_sum.std().fillna(0)
     data["sum_zscore"] = (data["sum"] - rolling_sum.mean()) / (rolling_std + 1e-6)
+
+    # === 5b. Sum trend features (multi-scale rolling statistics) ===
+    # Captures whether recent sums are trending higher/lower and whether
+    # volatility is changing — complements sum_zscore's single window.
+    for w in [5, 20, 50]:
+        data[f"sum_rolling_mean_{w}"] = data["sum"].rolling(w, min_periods=1).mean()
+        data[f"sum_rolling_std_{w}"] = data["sum"].rolling(w, min_periods=1).std().fillna(0)
 
     # === 6. Even/odd count (vectorized) ===
     ball_arr_all = data[ball_cols_all].values
@@ -185,15 +193,23 @@ def engineer_features(data: pd.DataFrame, config: dict, log) -> pd.DataFrame:
         pos_freq = data[col].value_counts().to_dict()
         data[f"{col}_pos_freq"] = data[col].map(pos_freq).fillna(0).astype(int)
 
+    # Defragment: sections 1-13 added many columns individually; consolidate
+    # before sections 14-16 to silence PerformanceWarning.
+    data = data.copy()
+
     # === 14. Draw spread features ===
     # Range and average gap between consecutive sorted balls capture
     # whether a draw is tightly clustered or widely spread.
     sorted_arr = np.sort(ball_arr, axis=1)
     data["draw_range"] = sorted_arr[:, -1] - sorted_arr[:, 0]
     if ball_arr.shape[1] > 1:
-        data["draw_mean_gap"] = np.diff(sorted_arr, axis=1).mean(axis=1)
+        diffs = np.diff(sorted_arr, axis=1)
+        data["draw_mean_gap"] = diffs.mean(axis=1)
+        # Consecutive number count: pairs of adjacent numbers in a draw
+        data["consecutive_count"] = (diffs == 1).sum(axis=1)
     else:
         data["draw_mean_gap"] = 0.0
+        data["consecutive_count"] = 0
 
     # === 15. Zone counts (low / mid / high third of the range) ===
     range_span = config["ball_game_range_high"] - config["ball_game_range_low"] + 1

--- a/lib/models/builder.py
+++ b/lib/models/builder.py
@@ -6,6 +6,7 @@ from sklearn.ensemble import (
     RandomForestClassifier,
     VotingClassifier,
 )
+from sklearn.linear_model import LogisticRegression
 
 
 def build_model(hgbc_params=None, calibration_cv=2):
@@ -54,7 +55,13 @@ def build_model(hgbc_params=None, calibration_cv=2):
     if hgbc_params:
         base_hgbc_kwargs.update(hgbc_params)
     hgbc = HistGradientBoostingClassifier(**base_hgbc_kwargs)
-    return VotingClassifier([("rf", rf), ("hgbc", hgbc)], voting="soft")
+    lr = LogisticRegression(
+        max_iter=1000,
+        class_weight="balanced",
+        random_state=42,
+        n_jobs=-1,
+    )
+    return VotingClassifier([("rf", rf), ("hgbc", hgbc), ("lr", lr)], voting="soft")
 
 
 def build_cv_model():

--- a/lib/models/predictor.py
+++ b/lib/models/predictor.py
@@ -280,16 +280,18 @@ def build_models(data: pd.DataFrame, config: dict, gamedir: str, stats: dict, lo
         y_cal      = y_train.iloc[cal_idx:]
 
         # Feature pruning on the fit portion only.
-        pruning_threshold = config.get("feature_pruning_threshold", 1e-4)
+        pruning_threshold = config.get("feature_pruning_threshold", 1e-3)
         if pruning_threshold > 0:
             prune_m = _PruneDT(max_depth=8, random_state=42)
             prune_m.fit(x_fit_ball, y_fit)
             mask = prune_m.feature_importances_ >= pruning_threshold
             if mask.sum() >= 5:
+                n_before = len(x_fit_ball.columns)
                 keep = x_fit_ball.columns[mask].tolist()
                 x_fit_ball  = x_fit_ball[keep]
                 x_cal_ball  = x_cal_ball[keep]
                 x_test_ball = x_test_ball[keep]
+                log.info(f"Ball{ball}: pruned {n_before - len(keep)}/{n_before} features (kept {len(keep)})")
 
         model_path = os.path.join(gamedir, config["model_save_path"], f"Ball{ball}.joblib")
         os.makedirs(os.path.dirname(model_path), exist_ok=True)
@@ -420,12 +422,12 @@ def generate_predictions(data, config, models, stats, log, test_scores=None, tes
     today_str = datetime.now().strftime('%Y-%m-%d')
 
     max_runs = config.get("test_prediction_runs", 10)
-    max_retries = config.get("max_prediction_retries", 20)
+    max_retries = config.get("max_prediction_retries", 50)
 
     # Hoist loop-invariant config/stats lookups
     num_main = len(config["game_balls"])
     game_has_extra = config.get("game_has_extra", False)
-    min_diversity = config.get("min_prediction_diversity", 2)
+    min_diversity = config.get("min_prediction_diversity", 3)
     include_extra_in_sum = config.get("include_extra_in_sum", False)
     no_duplicates = config.get("no_duplicates", False)
     min_confidence = config.get("min_confidence", 0.01)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -6,6 +6,7 @@ from sklearn.ensemble import (
     RandomForestClassifier,
     VotingClassifier,
 )
+from sklearn.linear_model import LogisticRegression
 
 from lib.models.builder import build_model, build_cv_model
 
@@ -16,6 +17,7 @@ def test_build_model_returns_voting_classifier():
     assert isinstance(model.estimators[0][1], CalibratedClassifierCV)
     assert isinstance(model.estimators[0][1].estimator, RandomForestClassifier)
     assert isinstance(model.estimators[1][1], HistGradientBoostingClassifier)
+    assert isinstance(model.estimators[2][1], LogisticRegression)
 
 
 def test_build_cv_model_returns_hgbc():

--- a/tests/test_builder_models.py
+++ b/tests/test_builder_models.py
@@ -6,6 +6,7 @@ from sklearn.ensemble import (
     RandomForestClassifier,
     VotingClassifier,
 )
+from sklearn.linear_model import LogisticRegression
 
 from lib.models import builder
 
@@ -16,16 +17,19 @@ def test_build_model_returns_voting_classifier():
     assert model.voting == "soft"
 
 
-def test_build_model_contains_rf_and_hgbc():
+def test_build_model_contains_rf_hgbc_and_lr():
     model = builder.build_model()
     names = [name for name, _ in model.estimators]
     assert "rf" in names
     assert "hgbc" in names
+    assert "lr" in names
     rf = dict(model.estimators)["rf"]
     hgbc = dict(model.estimators)["hgbc"]
+    lr = dict(model.estimators)["lr"]
     assert isinstance(rf, CalibratedClassifierCV)
     assert isinstance(rf.estimator, RandomForestClassifier)
     assert isinstance(hgbc, HistGradientBoostingClassifier)
+    assert isinstance(lr, LogisticRegression)
 
 
 def test_build_model_classifier_returns_voting_classifier():


### PR DESCRIPTION
## Summary
- **Feature pruning**: Raise default threshold 1e-4 → 1e-3, now drops ~50% of noise features per ball. Log pruning stats.
- **Temporal features**: Configurable recent_count windows (adds window=50), sum rolling mean/std at [5,20,50], consecutive number count per draw
- **Ensemble diversity**: Add LogisticRegression (multinomial softmax, class_weight='balanced') as 3rd estimator alongside RF + HGBC
- **Prediction diversity**: min_prediction_diversity 2 → 3 (at least 3 balls must differ), max_retries 20 → 50

## Test plan
- [x] All 59 unit tests pass (93% coverage)
- [x] E2E: `python lottery.py NJ_Pick6 --dry-run --force-retrain` completes — 7/10 runs succeed with stricter diversity
- [x] Feature pruning confirmed: 56-69 features kept per ball (out of 134)
- [x] LR convergence warning only on tiny test datasets (expected, harmless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)