### PR TITLE
Fix automerge failing when calibrated_temps.json has local changes

### DIFF
--- a/lib/data/github.py
+++ b/lib/data/github.py
@@ -83,16 +83,9 @@ class GitHubAutoMerge:
             print("Initialization failed. Cannot proceed.")
             return
 
-        # Stage everything first, then check if there's anything to do
-        print("Staging all modified and untracked files...")
-        try:
-            self.repo.git.add(A=True)
-        except Exception as e:
-            print(f"Error staging files: {e}")
-            return
-
-        if not self.repo.index.diff("HEAD"):
-            print("No staged changes to commit. Aborting automerge workflow.")
+        # Bail out early if there's nothing to commit
+        if not self.repo.is_dirty(index=True, working_tree=True, untracked_files=True):
+            print("No changes to commit. Aborting automerge workflow.")
             return
 
         # Fetch latest remote state so the new branch is up to date
@@ -114,6 +107,14 @@ class GitHubAutoMerge:
             remote_main = self.repo.remotes[self.remote_name].refs[self.main_branch]
             new_branch = self.repo.create_head(new_branch_name, commit=remote_main.commit)
             new_branch.checkout()
+
+            # Stage everything now that we're on the new branch
+            print("Staging all modified and untracked files...")
+            self.repo.git.add(A=True)
+
+            if not self.repo.index.diff("HEAD"):
+                print("No staged changes to commit. Aborting automerge workflow.")
+                return
 
             # Commit — signing is handled by git config (commit.gpgsign).
             # Avoid passing -S explicitly: it forces GPG-style signing and


### PR DESCRIPTION
## Summary
- Moves `git add -A` to happen **after** the new branch is checked out, instead of before
- Previously, staging files (including `calibrated_temps.json`) on `main` and then trying to `git checkout` a branch based on remote main would fail because git refused to overwrite staged changes that differed from the target commit
- Also simplifies the early-exit dirty check — no need to stage-then-reset just to detect changes

## Root cause
The systemd service ran nightly but automerge silently failed every time `calibrated_temps.json` was updated by the pipeline, leaving predictions uncommitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)