### PR TITLE
Revert TMPDIR=/tmp override that broke SSH commit signing

### DIFF
--- a/lib/data/github.py
+++ b/lib/data/github.py
@@ -116,11 +116,7 @@ class GitHubAutoMerge:
                 print("No staged changes to commit. Aborting automerge workflow.")
                 return
 
-            # The service sets TMPDIR=/run/user/1000, which only exists during an active
-            # login session. Git writes the SSH signing buffer there, failing at midnight
-            # when no session is open. Override TMPDIR to /tmp for this commit only.
-            with self.repo.git.custom_environment(TMPDIR='/tmp'):
-                self.repo.git.commit('-m', commit_message)
+            self.repo.git.commit('-m', commit_message)
 
             print(f"Committed changes on branch '{new_branch_name}'.")
 


### PR DESCRIPTION
## Root cause (confirmed via SELinux audit log)

The signing failure is an SELinux AVC denial:
```
denied { open } for comm="ssh-keygen"
  scontext=system_u:system_r:ssh_keygen_t:s0
  tcontext=system_u:object_r:initrc_tmp_t:s0
```

The systemd service runs in `initrc_t` SELinux domain. Commit `7c9087f` overrode `TMPDIR` to `/tmp`, but files created in `/tmp` by an `initrc_t` process get the `initrc_tmp_t` SELinux label. When git then spawns `ssh-keygen` (which transitions to `ssh_keygen_t`), SELinux denies it from opening the `initrc_tmp_t` signing buffer.

## Fix

`/run/user/1000/` has `user_tmp_t` label, which `ssh_keygen_t` can open. User linger is already enabled (`loginctl show-user sage | grep Linger=yes`), so that directory persists at midnight without an active login session. Removing the `TMPDIR='/tmp'` Python override lets git use the service's `TMPDIR=/run/user/1000`, producing signing buffers that `ssh_keygen_t` can access.

## Test plan
- [ ] Unit tests: `pipenv run pytest` (59 pass)
- [ ] End-to-end: `python lottery.py NJ_Pick6 --dry-run --force-retrain`
- [ ] Verify next midnight service run produces a signed commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)