### PR TITLE
Fix neg_log_loss class mismatch in HGBC tuning

### DIFF
--- a/lib/models/predictor.py
+++ b/lib/models/predictor.py
@@ -127,9 +127,21 @@ def _tune_hgbc(x_train, y_train, log, n_trials=50):
     Returns the best parameter dict found.
     """
     from sklearn.ensemble import HistGradientBoostingClassifier
+    from sklearn.metrics import log_loss
     from sklearn.model_selection import TimeSeriesSplit, cross_val_score
 
     optuna.logging.set_verbosity(optuna.logging.WARNING)
+
+    # Pre-compute full label set so the scorer never fails when a CV fold's
+    # test split is missing some classes (common with rare ball values).
+    all_labels = np.sort(np.unique(y_train)).tolist()
+
+    def _nll_scorer(estimator, X, y):
+        try:
+            proba = estimator.predict_proba(X)
+            return -log_loss(y, proba, labels=all_labels)
+        except Exception:
+            return -100.0
 
     def _objective(trial):
         params = {
@@ -143,7 +155,7 @@ def _tune_hgbc(x_train, y_train, log, n_trials=50):
         cv = TimeSeriesSplit(n_splits=3)
         try:
             scores = cross_val_score(model, x_train, y_train, cv=cv,
-                                     scoring="neg_log_loss", n_jobs=1)
+                                     scoring=_nll_scorer, n_jobs=1)
             result = float(np.nanmean(scores))
             return result if not np.isnan(result) else -100.0
         except Exception:


### PR DESCRIPTION
## Summary

`TimeSeriesSplit` CV folds can produce test splits that are missing rare ball values (e.g. a number that only appears 30 times in 8,000 draws). sklearn's `neg_log_loss` scorer raises `ValueError` internally when the train and test class sets differ — it catches the exception itself and returns NaN, bypassing our `except` clause. All trials then return NaN, Optuna rejects them all, and `study.best_trial` raises `ValueError: No trials are completed yet`.

Fix: replace the `"neg_log_loss"` string scorer with a custom callable `_nll_scorer` that pre-computes the full label set from `y_train` and passes it explicitly to `log_loss(labels=all_labels)`.

## Test plan

- [x] `pipenv run pytest` — 61/61 pass, 92% coverage
- [x] Reproduces original error on NJ_Cash5 (34 unique ball values, rare classes cause fold mismatch); fixed with explicit labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)