### PR TITLE
Track model param JSON files in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 **/.idea/
 **/.DS_Store
 **/*.joblib
-**/calibrated_temps.json
 **/__pycache__/
 **/htmlcov/
 **/.coverage


### PR DESCRIPTION
## Summary

Removes `**/calibrated_temps.json` from `.gitignore` so all three tuning output files are tracked:

- `calibrated_temps.json` — per-ball temperature calibration (was incorrectly ignored)
- `best_params.json` — tuned HGBC hyperparameters (already tracked)
- `sampling_params.json` — tuned smoothing/recency/regime temps (already tracked)

These are small JSON files representing expensive tuning runs (~28h). Tracking them means any machine that clones the repo gets the tuned state without re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)