### PR TITLE
Replace fixed regime thresholds with rolling percentile classification

### DIFF
--- a/lib/data/features.py
+++ b/lib/data/features.py
@@ -119,24 +119,35 @@ def engineer_features(data: pd.DataFrame, config: dict, log) -> pd.DataFrame:
 
     if entropy_windows:
         if low_thr is None or high_thr is None:
-            # Percentiles computed on the training portion only to avoid
-            # look-ahead bias: test-set rows must not influence the thresholds
-            # used to classify them. Uses the same train_ratio as predictor.py.
+            # Rolling percentile thresholds: for row i, the regime is determined
+            # by where entropy[i] sits within the preceding regime_window draws.
+            # shift(1) makes it causal — row i does not influence its own threshold.
+            # This adapts to long-run entropy drift (e.g. from game range expansions)
+            # while remaining fully leak-free.
+            regime_window = config.get("regime_window", 200)
+            entropy_series = pd.Series(entropy_main)
+            shifted = entropy_series.shift(1)
+            lo_rolling = shifted.rolling(regime_window, min_periods=10).quantile(0.33)
+            hi_rolling = shifted.rolling(regime_window, min_periods=10).quantile(0.66)
+
+            # Fall back to train-split percentiles for early rows that lack
+            # sufficient rolling history (fewer than min_periods draws).
             train_ratio = config.get("train_ratio", 0.8)
             train_n = max(1, int(n * train_ratio))
-            train_entropy = entropy_main[:train_n]
-            low_thr_val = np.percentile(train_entropy, 33)
-            high_thr_val = np.percentile(train_entropy, 66)
+            fallback_lo = np.percentile(entropy_main[:train_n], 33)
+            fallback_hi = np.percentile(entropy_main[:train_n], 66)
+            lo_vals = lo_rolling.fillna(fallback_lo).values
+            hi_vals = hi_rolling.fillna(fallback_hi).values
         else:
-            low_thr_val = low_thr
-            high_thr_val = high_thr
+            lo_vals = np.full(n, low_thr)
+            hi_vals = np.full(n, high_thr)
     else:
-        low_thr_val = 0.0
-        high_thr_val = 0.0
+        lo_vals = np.zeros(n)
+        hi_vals = np.zeros(n)
 
     data["regime"] = np.where(
-        entropy_main < low_thr_val, 0,
-        np.where(entropy_main > high_thr_val, 2, 1)
+        entropy_main < lo_vals, 0,
+        np.where(entropy_main > hi_vals, 2, 1)
     )
 
     # === 9. Global frequency per ball (vectorized cumulative — leak-free) ===


### PR DESCRIPTION
## Problem
Regime boundaries were computed from fixed percentiles of the training split's entropy distribution. For Cash5 — which had four game range expansions over 33 years (1-38 → 1-40 → 1-43 → 1-45) — entropy drifted upward monotonically as the range grew. The fixed thresholds calibrated on early, low-entropy draws classified **94.8% of test-set rows as Regime 2**, making regime-specific model behavior meaningless on the test set.

## Fix
Rolling percentile thresholds: for each row `i`, the regime is determined by where `entropy[i]` sits within the preceding `regime_window` (default 200) draws. `shift(1)` ensures full causality — no look-ahead. Early rows with fewer than 10 draws of history fall back to train-split percentiles.

Config override (`entropy_low_threshold` / `entropy_high_threshold`) still bypasses the rolling logic for games that need fixed thresholds.

## Result
| Game | Before (test R0/R1/R2) | After (test R0/R1/R2) |
|---|---|---|
| Cash5 | 0.1% / 2.7% / 94.8% | **33.7% / 32.5% / 33.8%** |
| Pick6 | skewed | **36.4% / 33.3% / 30.3%** |

## Test plan
- [x] `pipenv run pytest` — 61/61 pass
- [x] `python lottery.py NJ_Pick6 --dry-run --force-retrain` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)