### PR TITLE
Auto-retrain saved models with stale feature signatures

### DIFF
--- a/lib/models/predictor.py
+++ b/lib/models/predictor.py
@@ -24,6 +24,23 @@ def _align_input(model, input_vec):
     return input_vec
 
 
+def _model_is_stale(model, current_cols, exact=False):
+    """
+    True if a saved model's fit-time features no longer line up with the
+    pipeline's current feature set, meaning it must be retrained.
+
+    exact=True (models fit on the full feature frame, e.g. MultiOutput):
+    any difference is stale — sklearn rejects extra columns at predict time.
+    exact=False (models fit on a pruned subset, scored via _align_input):
+    only *removed* features make it stale; extra new columns are tolerated.
+    """
+    expected = getattr(model, "feature_names_in_", None)
+    if expected is None:
+        return False
+    expected, current = set(expected), set(current_cols)
+    return expected != current if exact else not expected.issubset(current)
+
+
 def _is_diverse(predictions, all_predictions, min_diversity):
     """True if predictions differ by at least min_diversity balls from every prior run."""
     for prior in all_predictions:
@@ -395,10 +412,15 @@ def build_models(data: pd.DataFrame, config: dict, gamedir: str, stats: dict, lo
     # --- Multi-output stacking: train on all balls at once, inject predictions as features ---
     mo_model_path = os.path.join(gamedir, config["model_save_path"], "MultiOutput.joblib")
     y_train_all = y_train_frame
+    mo_model = None
     if os.path.exists(mo_model_path) and not force_retrain:
-        mo_model = joblib.load(mo_model_path)
-        log.info(f"Loaded existing multi-output model: {mo_model_path}")
-    else:
+        candidate = joblib.load(mo_model_path)
+        if _model_is_stale(candidate, x_train.columns, exact=True):
+            log.warning("MultiOutput: saved model's features don't match the current feature set; retraining.")
+        else:
+            mo_model = candidate
+            log.info(f"Loaded existing multi-output model: {mo_model_path}")
+    if mo_model is None:
         mo_model = _MOC(_MORF(n_estimators=50, max_depth=8, random_state=42, n_jobs=-1))
         mo_model.fit(x_train, y_train_all)
         joblib.dump(mo_model, mo_model_path)
@@ -433,10 +455,15 @@ def build_models(data: pd.DataFrame, config: dict, gamedir: str, stats: dict, lo
             valid_mask = (vals >= va_lo) & (vals <= va_hi)
             y_appear_train[np.where(valid_mask), vals[valid_mask] - va_lo] = 1
 
+        va_model = None
         if os.path.exists(va_model_path) and not force_retrain:
-            va_model = joblib.load(va_model_path)
-            log.info(f"Loaded existing value-appearance model: {va_model_path}")
-        else:
+            candidate = joblib.load(va_model_path)
+            if _model_is_stale(candidate, x_train.columns, exact=True):
+                log.warning("ValueAppear: saved model's features don't match the current feature set; retraining.")
+            else:
+                va_model = candidate
+                log.info(f"Loaded existing value-appearance model: {va_model_path}")
+        if va_model is None:
             va_model = _MOC(_MORF(n_estimators=50, max_depth=8, random_state=42, n_jobs=-1))
             va_model.fit(x_train, y_appear_train)
             joblib.dump(va_model, va_model_path)
@@ -498,10 +525,15 @@ def build_models(data: pd.DataFrame, config: dict, gamedir: str, stats: dict, lo
             with open(params_path, "w") as _f:
                 json.dump(best_params_store, _f, indent=2)
 
+        model = None
         if os.path.exists(model_path) and not force_retrain:
-            model = joblib.load(model_path)
-            log.info(f"Loaded existing model: {model_path}")
-        else:
+            candidate = joblib.load(model_path)
+            if _model_is_stale(candidate, x_train_ball.columns):
+                log.warning(f"Ball{ball}: saved model references features no longer produced; retraining.")
+            else:
+                model = candidate
+                log.info(f"Loaded existing model: {model_path}")
+        if model is None:
             min_class_count = int(y_fit.value_counts().min())
             calibration_cv  = min(2, min_class_count) if min_class_count >= 2 else None
             if calibration_cv is None:
@@ -576,10 +608,15 @@ def build_models(data: pd.DataFrame, config: dict, gamedir: str, stats: dict, lo
             with open(params_path, "w") as _f:
                 json.dump(best_params_store, _f, indent=2)
 
+        model = None
         if os.path.exists(model_path) and not force_retrain:
-            model = joblib.load(model_path)
-            log.info(f"Loaded existing model: {model_path}")
-        else:
+            candidate = joblib.load(model_path)
+            if _model_is_stale(candidate, x_train.columns):
+                log.warning(f"{extra_col}: saved model references features no longer produced; retraining.")
+            else:
+                model = candidate
+                log.info(f"Loaded existing model: {model_path}")
+        if model is None:
             min_class_count = int(y_fit_ex.value_counts().min())
             calibration_cv  = min(2, min_class_count) if min_class_count >= 2 else None
             if calibration_cv is None:

--- a/tests/test_stale_models.py
+++ b/tests/test_stale_models.py
@@ -1,0 +1,74 @@
+# tests/test_stale_models.py
+#
+# Saved models whose fit-time features no longer match the pipeline's current
+# feature set must be retrained automatically instead of crashing at predict
+# time (this broke every cron machine when PR #742 added global_recent features).
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+from sklearn.tree import DecisionTreeClassifier
+
+import lib.models.builder as builder
+from lib.data.features import engineer_features
+from lib.data.normalize import normalize_features
+from lib.models.predictor import _model_is_stale, prepare_statistics, build_models
+
+
+def _fitted_model(columns):
+    x = pd.DataFrame(np.random.rand(20, len(columns)), columns=columns)
+    y = np.random.randint(0, 2, 20)
+    return DecisionTreeClassifier(max_depth=2).fit(x, y)
+
+
+def test_not_stale_when_features_match():
+    model = _fitted_model(["a", "b", "c"])
+    assert not _model_is_stale(model, ["a", "b", "c"])
+    assert not _model_is_stale(model, ["a", "b", "c"], exact=True)
+
+
+def test_new_columns_stale_only_in_exact_mode():
+    model = _fitted_model(["a", "b"])
+    current = ["a", "b", "new_feature"]
+    # subset mode tolerates new columns (_align_input filters them out)
+    assert not _model_is_stale(model, current)
+    # exact mode (models fit on the full frame) must retrain
+    assert _model_is_stale(model, current, exact=True)
+
+
+def test_removed_columns_stale_in_both_modes():
+    model = _fitted_model(["a", "b", "gone"])
+    assert _model_is_stale(model, ["a", "b"])
+    assert _model_is_stale(model, ["a", "b"], exact=True)
+
+
+def test_model_without_feature_names_never_stale():
+    model = LinearRegression().fit(np.random.rand(10, 3), np.random.rand(10))
+    # fit on a bare ndarray → no feature_names_in_ → nothing to validate
+    assert not _model_is_stale(model, ["a"])
+    assert not _model_is_stale(model, ["a"], exact=True)
+
+
+def test_build_models_retrains_stale_models_instead_of_crashing(
+        tmp_path, test_config, dummy_data, dummy_log):
+    """Reproduces the cron crash: models saved before a feature was added
+    used to raise 'feature names unseen at fit time' on the next plain run."""
+    builder.build_model = lambda **kw: LinearRegression()
+    config = dict(test_config)
+    config["model_save_path"] = "models"
+    (tmp_path / "models").mkdir()
+
+    data = engineer_features(dummy_data.copy(), config, dummy_log)
+    data = normalize_features(data, config)
+    stats = prepare_statistics(data, config, dummy_log)
+    build_models(data, config, str(tmp_path), stats, dummy_log, force_retrain=True)
+
+    # Simulate a feature-engineering PR landing after the models were saved
+    data_new = data.copy()
+    data_new["brand_new_feature"] = 0.5
+
+    # Without auto-retrain this raised ValueError at MultiOutput.predict
+    models, scores = build_models(data_new, config, str(tmp_path), stats,
+                                  dummy_log, force_retrain=False)
+    assert "multi_output" in models
+    assert set(config["game_balls"]).issubset(scores.keys())


### PR DESCRIPTION
Fixes the failure that has crashed the nightly cron on every machine since 2026-06-05: models saved before #742's `global_recent` features raise `ValueError: feature names unseen at fit time` at `MultiOutput.predict`, killing the run before automerge.

`build_models` now checks each loaded model's `feature_names_in_` against the current feature frame and retrains on mismatch (exact match for full-frame MultiOutput/ValueAppear; subset match for pruned per-ball/extra models, which tolerate new columns via `_align_input`). Feature-engineering PRs no longer require a manual `--force-retrain` on each machine.

Testing: 87 tests pass (5 new, incl. an integration test reproducing the crash); e2e `NJ_Pick6 --dry-run --force-retrain` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)