### PR TITLE
Respect no_duplicates in consensus predictions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /models/
+**/models/calibrated_temps.json
+**/models/best_params.json
+**/models/sampling_params.json
 **/venv/
 **/.idea/
 **/.DS_Store

--- a/lib/models/predictor.py
+++ b/lib/models/predictor.py
@@ -41,6 +41,38 @@ def _model_is_stale(model, current_cols, exact=False):
     return expected != current if exact else not expected.issubset(current)
 
 
+def _consensus_prediction(valid_runs, config):
+    """
+    Majority vote per ball position across runs. When no_duplicates is set,
+    main-ball positions must not repeat a number already chosen: each position
+    takes its most-voted unused value, falling back to the most-voted unused
+    value across all main positions, then to the lowest unused number in range.
+    The extra ball (if any) is a separate pool and may match a main ball.
+    """
+    from collections import Counter
+    num_main = len(config["game_balls"])
+    no_dup = config.get("no_duplicates", False)
+
+    consensus, used = [], set()
+    for pos_idx in range(len(valid_runs[0]["predicted"])):
+        counts = Counter(r["predicted"][pos_idx] for r in valid_runs)
+        is_main = pos_idx < num_main
+        dedup = no_dup and is_main
+
+        pick = next((c for c, _ in counts.most_common() if not (dedup and c in used)), None)
+        if pick is None:
+            pool = Counter(v for r in valid_runs for v in r["predicted"][:num_main])
+            pick = next((c for c, _ in pool.most_common() if c not in used), None)
+        if pick is None:
+            lo, hi = config["ball_game_range_low"], config["ball_game_range_high"]
+            pick = next(n for n in range(lo, hi + 1) if n not in used)
+
+        if dedup:
+            used.add(pick)
+        consensus.append(pick)
+    return consensus
+
+
 def _is_diverse(predictions, all_predictions, min_diversity):
     """True if predictions differ by at least min_diversity balls from every prior run."""
     for prior in all_predictions:
@@ -862,11 +894,7 @@ def generate_predictions(data, config, models, stats, log, test_scores=None, tes
     # Consensus prediction: majority vote per ball position across all runs
     valid_runs = [p for p in all_predictions if "predicted" in p]
     if len(valid_runs) >= 2:
-        from collections import Counter
-        consensus = []
-        for pos_idx in range(len(valid_runs[0]["predicted"])):
-            counts = Counter(r["predicted"][pos_idx] for r in valid_runs)
-            consensus.append(counts.most_common(1)[0][0])
+        consensus = _consensus_prediction(valid_runs, config)
         all_predictions.append({
             "run": "consensus",
             "date": today_str,

--- a/tests/test_consensus.py
+++ b/tests/test_consensus.py
@@ -1,0 +1,57 @@
+# tests/test_consensus.py
+
+from lib.models.predictor import _consensus_prediction
+
+BASE_CONFIG = {
+    "game_balls": [1, 2, 3, 4, 5],
+    "no_duplicates": True,
+    "ball_game_range_low": 1,
+    "ball_game_range_high": 60,
+}
+
+
+def _runs(*predictions):
+    return [{"predicted": list(p)} for p in predictions]
+
+
+def test_simple_majority_no_conflict():
+    runs = _runs([1, 2, 3, 4, 5], [1, 2, 3, 4, 6], [1, 2, 3, 4, 5])
+    assert _consensus_prediction(runs, BASE_CONFIG) == [1, 2, 3, 4, 5]
+
+
+def test_no_duplicates_picks_next_most_voted():
+    # Position 3's majority value (35) is already used by position 2;
+    # consensus must fall back to position 3's runner-up (40).
+    runs = _runs(
+        [19, 30, 35, 35, 33],
+        [19, 30, 35, 40, 33],
+        [19, 30, 35, 35, 33],
+    )
+    result = _consensus_prediction(runs, BASE_CONFIG)
+    assert result == [19, 30, 35, 40, 33]
+    assert len(set(result)) == 5
+
+
+def test_duplicates_allowed_when_config_off():
+    config = dict(BASE_CONFIG, no_duplicates=False)
+    runs = _runs([19, 30, 35, 35, 33], [19, 30, 35, 35, 33])
+    assert _consensus_prediction(runs, config) == [19, 30, 35, 35, 33]
+
+
+def test_extra_ball_may_repeat_main_ball():
+    # 6 values = 5 mains + extra; extra (position 5) is a separate pool
+    config = dict(BASE_CONFIG)
+    runs = _runs([1, 2, 3, 4, 5, 3], [1, 2, 3, 4, 5, 3])
+    result = _consensus_prediction(runs, config)
+    assert result == [1, 2, 3, 4, 5, 3]
+
+
+def test_all_candidates_used_falls_back_to_pool_then_range():
+    # Every vote at every position is the same number — positions after the
+    # first must fall back to unused numbers, never duplicating.
+    runs = _runs([7, 7, 7, 7, 7], [7, 7, 7, 7, 7])
+    result = _consensus_prediction(runs, BASE_CONFIG)
+    assert result[0] == 7
+    assert len(set(result)) == 5
+    assert all(BASE_CONFIG["ball_game_range_low"] <= v <= BASE_CONFIG["ball_game_range_high"]
+               for v in result)


### PR DESCRIPTION
- Consensus majority vote could emit duplicate main balls (spotted in M4L's `[19, 30, 35, 35, 33, 2]`). Extracted `_consensus_prediction()` with proper `no_duplicates` handling + 5 tests.
- Gitignore `calibrated_temps.json`/`best_params.json`/`sampling_params.json` under game model dirs — per-machine artifacts whose tracking caused spurious deletions from test-fixture cleanup (see #743's pull showing `delete mode calibrated_temps.json`).

Testing: 92 tests pass; e2e `NJ_Pick6 --dry-run --force-retrain` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)