### PR TITLE
Log already-deleted remote branch as info, not a warning

### DIFF
--- a/lib/data/github.py
+++ b/lib/data/github.py
@@ -136,12 +136,21 @@ class GitHubAutoMerge:
             merged = True
             print("Pull request merged successfully.")
 
-            # Delete the remote branch after a successful merge
+            # Delete the remote branch after a successful merge. With GitHub's
+            # "automatically delete head branches" enabled, the ref is usually
+            # gone before we get here -- that's success, not a warning.
             try:
                 self.repo.git.push(self.remote_name, '--delete', new_branch_name)
                 print(f"Deleted remote branch '{new_branch_name}'.")
             except Exception as e:
-                print(f"Warning: could not delete remote branch '{new_branch_name}': {e}")
+                try:
+                    branch_gone = not self.repo.git.ls_remote('--heads', self.remote_name, new_branch_name)
+                except Exception:
+                    branch_gone = False
+                if branch_gone:
+                    print(f"Remote branch '{new_branch_name}' was already deleted by GitHub.")
+                else:
+                    print(f"Warning: could not delete remote branch '{new_branch_name}': {e}")
 
             # Switch back to main and pull the merged result
             self.repo.git.checkout(self.main_branch)


### PR DESCRIPTION
## Summary
The nightly automerge run logs a warning every night:

```
Warning: could not delete remote branch 'automerge-branch-...': ... cannot lock ref ... unable to resolve reference
```

The repo has GitHub's **"Automatically delete head branches"** enabled, so the branch is already gone by the time the script tries to delete it. The log message was inaccurate — it reported a failure to do something that was already done.

## Change
On delete failure, check via `git ls-remote` whether the ref actually still exists. If it's gone, log it as normal cleanup (`already deleted by GitHub`); the warning now only fires for genuine failures.

## Testing
- `pipenv run pytest` — 92 passed
- `pipenv run python lottery.py NJ_Pick6 --dry-run --force-retrain` — completed without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)