### PR TITLE
Exit non-zero when the automerge workflow genuinely fails

### DIFF
--- a/lib/data/github.py
+++ b/lib/data/github.py
@@ -78,15 +78,20 @@ class GitHubAutoMerge:
         This method stages all changes in the working directory and then executes
         the entire workflow on the repository. It commits, pushes, creates a PR,
         and merges it.
+
+        Returns:
+            bool: True if the workflow succeeded or there was nothing to commit,
+            False if any step (commit, push, PR creation, merge) failed. Cleanup
+            of the already-merged branch is best-effort and never fails the run.
         """
         if not self.repo or not self.g:
             print("Initialization failed. Cannot proceed.")
-            return
+            return False
 
         # Bail out early if there's nothing to commit
         if not self.repo.is_dirty(index=True, working_tree=True, untracked_files=True):
             print("No changes to commit. Aborting automerge workflow.")
-            return
+            return True
 
         # Fetch latest remote state so the new branch is up to date
         print(f"Fetching latest '{self.main_branch}'...")
@@ -94,7 +99,7 @@ class GitHubAutoMerge:
             self.repo.git.fetch(self.remote_name, self.main_branch)
         except Exception as e:
             print(f"Failed to fetch '{self.main_branch}': {e}")
-            return
+            return False
 
         # Define branch names and commit message
         new_branch_name = f'automerge-branch-{os.urandom(4).hex()}'
@@ -115,7 +120,7 @@ class GitHubAutoMerge:
 
             if not self.repo.index.diff("HEAD"):
                 print("No staged changes to commit. Aborting automerge workflow.")
-                return
+                return True
 
             self.repo.git.commit('-m', commit_message)
 
@@ -157,11 +162,14 @@ class GitHubAutoMerge:
             print(f"Switched to local branch '{self.main_branch}'.")
             self.repo.git.pull(self.remote_name, self.main_branch)
             print(f"Pulled latest changes to local branch '{self.main_branch}'.")
+            return True
 
         except git.GitError as e:
             print(f"Git operation failed: {e}")
+            return False
         except Exception as e:
             print(f"GitHub API operation failed: {e}")
+            return False
         finally:
             if merged:
                 try:

--- a/lottery.py
+++ b/lottery.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import sys
 import warnings
 
 # Cap OpenMP threads before sklearn imports. On many-core machines (e.g. 24 cores)
@@ -80,10 +81,12 @@ def run_lottery(gamedir, args):
         log.info("Running GitHub automerge workflow...")
         if not github_pat or not repo_path or not github_owner or not github_repo:
             log.error("Missing GitHub environment variables. Automerge aborted.")
-            return
+            sys.exit(1)
         automator = GitHubAutoMerge(repo_path=repo_path, github_pat=github_pat, github_owner=github_owner,
             github_repo_name=github_repo, )
-        automator.run_automerge_workflow()
+        if not automator.run_automerge_workflow():
+            log.error("Automerge workflow failed. Predictions were not merged to GitHub.")
+            sys.exit(1)
 
     log.info("Loading raw data...")
     data = load_data(gamedir)


### PR DESCRIPTION
## Summary
Follow-up to #764. A genuinely failed automerge (commit, push, PR creation, or merge) previously exited 0: `run_automerge_workflow()` caught every exception, printed it, and returned `None`, so predictions could be left unshipped while `lottery.service` showed green.

## Changes
- `run_automerge_workflow()` now returns `True` on success — including nothing-to-commit no-ops — and `False` when any workflow step fails.
- `lottery.py` exits 1 when the workflow returns `False`, and also when the GitHub env vars are missing (previously a soft log-and-continue). `lottery-cron.sh` already propagates the exit code, so systemd will now show these as failures.
- Cleanup of the already-merged branch stays best-effort: by that point the predictions are merged, so a leftover branch logs a warning but never fails the run.

## Testing
- `pipenv run pytest` — 92 passed
- `pipenv run python lottery.py NJ_Pick6 --dry-run --force-retrain` — completed, exit code 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)