### PR TITLE
Fix matrix-era data pollution; add expected-payout ticket selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ python lottery.py <GAMEDIRECTORY>
 - `--automerge` — Commit and merge prediction exports to GitHub (requires `.env`)
 - `--draws N` — Predict the next N scheduled draw dates (default 1); one prediction file per draw date
 - `--update-data` — Fetch the latest winning numbers from the NJ Lottery API (`lib/data/fetch.py`) and append them to the game's source CSV before running
+- `--unpopular` — Select tickets for expected *payout* rather than predicted numbers. Bypasses model training entirely: samples uniformly over the ticket space and keeps combinations other players avoid (balls above 31, no consecutive runs or arithmetic progressions, not a past winning combination). **Does not change the odds of winning** — it raises the expected share of a pari-mutuel prize by reducing the number of co-winners. See `lib/models/unpopularity.py`.
 
 **Run all tests:**
 ```shell
@@ -71,6 +72,8 @@ Each game (e.g., `NJ_Pick6`, `Powerball`, `Megamillions`, `NJ_Cash4Life`, `NJ_Ca
 
 ### Config fields
 `game_balls` is a list like `[1,2,3,4,5,6]` (not ball values — these are ball position indices used to generate column names `Ball1..Ball6`). Games with an extra ball (PowerBall, MegaBall, CashBall) set `game_has_extra: true` and define `game_extra_col`, `game_balls_extra_low/high`.
+
+`matrix_start` (ISO date, optional but set for every game that needs it) truncates the source data to the first draw of the game's **current ball matrix**. Games change their matrix periodically (NJ Cash 5 has run as 5/38, 5/40, 5/43 and now 5/45 since 2020-06-29), and older draws are samples from a different distribution — formerly-impossible balls look permanently cold and the sum statistics that drive the prediction filter centre on the wrong value. `load_data` applies the cutoff and also drops exact duplicate rows. **Update this whenever a game changes its matrix.**
 
 Optional config fields: `lag_window` (default 5), `entropy_windows` (default [10,25,50]), `entropy_low_threshold`, `entropy_high_threshold`, `regime_temperatures` (default {0:0.8, 1:1.2, 2:1.6}), `input_sample_window` (default 10), `test_prediction_runs` (default 10), `max_prediction_retries` (default 20), `min_confidence` (default 0.01), `include_extra_in_sum`, `prediction_smoothing` (default 0.3 — uniform mixture weight to prevent mode collapse), `calibration_ratio` (default 0.15 — fraction of train data held out for temperature calibration), `freq_decay` (default 0.97 — exponential decay for recency-weighted frequency features), `accuracy_allowance` (default 0.0 — min accuracy delta vs. baseline to accept a retrained model), `draw_days` (list of weekday names the game draws on, e.g. `["Monday", "Thursday", "Saturday"]`; used by `lib/data/schedule.py` to pick prediction target dates — absent means daily), `fetch_game_name` (the game's name in the NJ Lottery API, e.g. `"Pick 6"`; required for `--update-data`).
 

--- a/Megamillions/config/config.json
+++ b/Megamillions/config/config.json
@@ -22,5 +22,6 @@
     "Tuesday",
     "Friday"
   ],
-  "fetch_game_name": "Mega Millions"
+  "fetch_game_name": "Mega Millions",
+  "matrix_start": "2017-10-31"
 }

--- a/NJ_Cash5/config/config.json
+++ b/NJ_Cash5/config/config.json
@@ -14,7 +14,7 @@
   "train_ratio": 0.8,
   "mean_allowance": 0.05,
   "mode_allowance": 0.1,
-  "hot_hand_or": 1.109,
+  "hot_hand_or": 1.0,
   "hot_hand_window": 10,
   "draw_days": [
     "Monday",

--- a/NJ_Cash5/config/config.json
+++ b/NJ_Cash5/config/config.json
@@ -25,5 +25,6 @@
     "Saturday",
     "Sunday"
   ],
-  "fetch_game_name": "Cash 5"
+  "fetch_game_name": "Cash 5",
+  "matrix_start": "2020-06-29"
 }

--- a/NJ_Pick6/config/config.json
+++ b/NJ_Pick6/config/config.json
@@ -15,7 +15,7 @@
   "train_ratio": 0.8,
   "mean_allowance": 0.05,
   "mode_allowance": 0.1,
-  "hot_hand_or": 1.039,
+  "hot_hand_or": 1.0,
   "hot_hand_window": 10,
   "draw_days": [
     "Monday",

--- a/NJ_Pick6/config/config.json
+++ b/NJ_Pick6/config/config.json
@@ -22,5 +22,6 @@
     "Thursday",
     "Saturday"
   ],
-  "fetch_game_name": "Pick 6"
+  "fetch_game_name": "Pick 6",
+  "matrix_start": "2022-04-07"
 }

--- a/Powerball/config/config.json
+++ b/Powerball/config/config.json
@@ -23,5 +23,6 @@
     "Wednesday",
     "Saturday"
   ],
-  "fetch_game_name": "Powerball"
+  "fetch_game_name": "Powerball",
+  "matrix_start": "2015-10-07"
 }

--- a/experiments/hypothesis_tests.py
+++ b/experiments/hypothesis_tests.py
@@ -21,7 +21,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from lib.config.loader import load_config, evaluate_config
 from lib.data.io import load_data
 
-GAMEDIR = "NJ_Pick6"
+GAMEDIR = sys.argv[1] if len(sys.argv) > 1 else "NJ_Pick6"
 N_PERMUTATIONS = 10_000
 RNG_SEED = 42
 rng = np.random.default_rng(RNG_SEED)

--- a/experiments/ledger_vs_random.py
+++ b/experiments/ledger_vs_random.py
@@ -171,7 +171,7 @@ def analyse(gamedir):
     pred_dir = os.path.join(gamedir, "predictions")
     files = sorted(f for f in os.listdir(pred_dir) if f.endswith(".json"))
 
-    scored, no_draw, leak = [], 0, 0
+    scored, no_draw, leak, unpopular = [], 0, 0, 0
     for fn in files:
         date = fn[:-5]
         if date not in actual_by_date:
@@ -183,6 +183,14 @@ def analyse(gamedir):
             continue
         with open(path) as fh:
             runs = json.load(fh)
+        # Unpopularity-mode files are a different generation process --
+        # uniform sampling selected for expected payout, with no predictive
+        # claim. Scoring them against a chance null is meaningless, and mixing
+        # them into the model's accuracy series would corrupt it.
+        if any(r.get("method") == "unpopularity" for r in runs):
+            unpopular += 1
+            continue
+
         tickets = [r["predicted"] for r in runs if r.get("predicted")]
         if not tickets:
             continue
@@ -210,6 +218,7 @@ def analyse(gamedir):
     print(f"prediction files                 : {len(files)}")
     print(f"  no matching draw yet           : {no_draw}")
     print(f"  DROPPED, not provably pre-draw : {leak}")
+    print(f"  skipped, unpopularity mode     : {unpopular}")
     print(f"  scored, leak-proof             : {len(scored)}"
           f"  [{scored[0]['date']} -> {scored[-1]['date']}]  {n_tix} tickets")
     print(f"\nOBSERVED  mean best-of-N hits    : {obs_best:.4f}")

--- a/experiments/ledger_vs_random.py
+++ b/experiments/ledger_vs_random.py
@@ -1,0 +1,264 @@
+"""
+Is the live prediction ledger beating chance?
+
+Scores every prediction file that is provably out-of-sample (its git add-time
+precedes the draw it names) against two Monte Carlo nulls:
+
+  A. unconstrained  - N uniform tickets per draw, no duplicates
+  B. sum-filtered   - the same, but each ticket must pass the identical
+                      mean/mode/stddev sum filter the pipeline applied
+
+Null B is the one that matters. The pipeline only emits sum-filtered tickets,
+and sum-filtered tickets sit in a denser region of ticket space, which lifts
+average balls-matched without improving the chance of any prize. If a result is
+significant under A but not under B, the "edge" is the filter and it is worth
+nothing.
+
+Balls matched is also reported alongside prize tiers. Tiers are the honest
+test: for a fair draw they cannot be improved, whereas average balls matched
+can be nudged by ticket placement alone.
+
+Run: python experiments/ledger_vs_random.py [GAMEDIR ...]
+"""
+
+import json
+import os
+import subprocess
+import sys
+from collections import Counter
+from math import comb
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from lib.config.loader import load_config, evaluate_config
+from lib.data.io import load_data
+
+N_SIMS = 20000
+RNG = np.random.default_rng(20260822)
+
+
+# ------------------------------------------------------------
+# Leak control
+# ------------------------------------------------------------
+def git_add_time(path):
+    """Author date of the commit that first added `path`, or None if untracked."""
+    out = subprocess.run(
+        ["git", "log", "--diff-filter=A", "--format=%aI", "-1", "--", path],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    return pd.to_datetime(out) if out else None
+
+
+def is_provably_prior(path, draw_date):
+    """
+    True if the file was committed before its draw could have happened.
+
+    Draws are in the evening; anything committed on or before the draw date is
+    prior to the draw. A file committed after its named date cannot be trusted
+    as out-of-sample and is dropped.
+    """
+    t = git_add_time(path)
+    if t is None:
+        return False
+    return t.tz_localize(None).normalize() <= pd.Timestamp(draw_date).normalize()
+
+
+# ------------------------------------------------------------
+# Scoring
+# ------------------------------------------------------------
+def _random_subsets(m, lo, hi, k):
+    """m uniform k-subsets of [lo, hi], vectorised."""
+    pool_n = hi - lo + 1
+    return np.argsort(RNG.random((m, pool_n)), axis=1)[:, :k] + lo
+
+
+def filtered_pool(sum_filter, lo, hi, k, target=40000, batch=40000, max_batches=40):
+    """A pool of uniform k-subsets that pass `sum_filter` (all subsets if None)."""
+    if sum_filter is None:
+        return _random_subsets(target, lo, hi, k)
+    keep = []
+    got = 0
+    for _ in range(max_batches):
+        cand = _random_subsets(batch, lo, hi, k)
+        ok = np.array([sum_filter(v) for v in cand.sum(axis=1)])
+        keep.append(cand[ok])
+        got += int(ok.sum())
+        if got >= target:
+            break
+    pool = np.concatenate(keep)
+    return pool[:target] if len(pool) else _random_subsets(target, lo, hi, k)
+
+
+def hit_pmf_from_pool(pool, actual, k):
+    """Empirical pmf of balls-matched for one draw, over a ticket pool."""
+    hits = np.isin(pool, np.fromiter(actual, dtype=pool.dtype)).sum(axis=1)
+    return np.bincount(hits, minlength=k + 1) / len(hits)
+
+
+def exact_hypergeom_pmf(lo, hi, k):
+    """Exact pmf of balls-matched for one uniform unconstrained ticket."""
+    from math import comb
+    n = hi - lo + 1
+    total = comb(n, k)
+    return np.array([comb(k, h) * comb(n - k, k - h) / total for h in range(k + 1)])
+
+
+def best_of_n_pmf(pmf, n):
+    """pmf of max over n iid draws: F_best(h) = F(h)**n."""
+    cdf = np.cumsum(pmf)
+    cdf_best = cdf ** n
+    return np.diff(np.concatenate([[0.0], cdf_best]))
+
+
+def filter_key(sum_filter, rec):
+    if sum_filter is None:
+        return None
+    return (round(rec.get("mean_sum", 0), 2), rec.get("mode_sum"), round(rec.get("stddev", 0), 2))
+
+
+def run_null(scored, per_draw_pmf, k, label):
+    """Monte Carlo the mean best-of-N across draws from exact per-draw pmfs."""
+    n_draws = len(scored)
+    best_pmfs = np.stack([
+        best_of_n_pmf(per_draw_pmf[i], scored[i]["n_tickets"]) for i in range(n_draws)
+    ])
+    vals = np.arange(k + 1)
+    exp_mean = float((best_pmfs * vals).sum(axis=1).mean())
+
+    # sample one "best" per draw per sim, vectorised via inverse-CDF
+    cdfs = np.cumsum(best_pmfs, axis=1)
+    u = RNG.random((N_SIMS, n_draws))
+    draws = (u[:, :, None] > cdfs[None, :, :]).sum(axis=2)
+    sim_mean = draws.mean(axis=1)
+    return exp_mean, sim_mean
+
+
+def tier_expectation(scored, per_draw_pmf, k):
+    """Expected number of match-h tickets across the whole ledger."""
+    exp = np.zeros(k + 1)
+    for i, s in enumerate(scored):
+        exp += per_draw_pmf[i] * s["n_tickets"]
+    return exp
+
+
+def make_sum_filter(rec, config):
+    """Rebuild the exact filter predictor.py applied, from the recorded stats."""
+    mean, mode, std = rec.get("mean_sum"), rec.get("mode_sum"), rec.get("stddev")
+    if mean is None or mode is None or std is None:
+        return None
+    ma = config["mean_allowance"]
+    mo = config["mode_allowance"]
+    return lambda s: (
+        mean * (1 - ma) <= s <= mean * (1 + ma)
+        and mode * (1 - mo) <= s <= mode * (1 + mo)
+        and (mean - std) <= s <= (mean + std)
+    )
+
+
+def analyse(gamedir):
+    config = evaluate_config(load_config(gamedir))
+    lo, hi = config["ball_game_range_low"], config["ball_game_range_high"]
+    ball_cols = [f"Ball{i}" for i in config["game_balls"]]
+    k = len(ball_cols)
+
+    df = load_data(gamedir)
+    df["Date"] = pd.to_datetime(df["Date"], format="mixed").dt.strftime("%Y-%m-%d")
+    actual_by_date = {r["Date"]: {int(r[c]) for c in ball_cols} for _, r in df.iterrows()}
+
+    pred_dir = os.path.join(gamedir, "predictions")
+    files = sorted(f for f in os.listdir(pred_dir) if f.endswith(".json"))
+
+    scored, no_draw, leak = [], 0, 0
+    for fn in files:
+        date = fn[:-5]
+        if date not in actual_by_date:
+            no_draw += 1
+            continue
+        path = os.path.join(pred_dir, fn)
+        if not is_provably_prior(path, date):
+            leak += 1
+            continue
+        with open(path) as fh:
+            runs = json.load(fh)
+        tickets = [r["predicted"] for r in runs if r.get("predicted")]
+        if not tickets:
+            continue
+        actual = actual_by_date[date]
+        rec = next((r for r in runs if "mean_sum" in r), {})
+        scored.append({
+            "date": date,
+            "n_tickets": len(tickets),
+            "hits": [len(actual & set(t)) for t in tickets],
+            "filter": make_sum_filter(rec, config),
+            "fkey": filter_key(make_sum_filter(rec, config), rec),
+        })
+
+    if not scored:
+        print(f"{gamedir}: nothing scoreable")
+        return
+
+    obs_best = float(np.mean([max(s["hits"]) for s in scored]))
+    obs_tiers = Counter(h for s in scored for h in s["hits"] if h >= 3)
+    n_tix = sum(s["n_tickets"] for s in scored)
+
+    print(f"\n{'=' * 74}")
+    print(f"{gamedir}   {k} of {hi}   (jackpot odds 1 in {comb(hi - lo + 1, k):,})")
+    print("=" * 74)
+    print(f"prediction files                 : {len(files)}")
+    print(f"  no matching draw yet           : {no_draw}")
+    print(f"  DROPPED, not provably pre-draw : {leak}")
+    print(f"  scored, leak-proof             : {len(scored)}"
+          f"  [{scored[0]['date']} -> {scored[-1]['date']}]  {n_tix} tickets")
+    print(f"\nOBSERVED  mean best-of-N hits    : {obs_best:.4f}")
+    print(f"OBSERVED  prize tiers            : "
+          + (", ".join(f"match-{h}: {c}" for h, c in sorted(obs_tiers.items(), reverse=True))
+             or "none above match-2"))
+
+    # ---- Null A: unconstrained uniform tickets -----------------------------
+    pmf_a = exact_hypergeom_pmf(lo, hi, k)
+    per_draw_a = [pmf_a] * len(scored)
+
+    # ---- Null B: tickets passing the same sum filter the pipeline applied ---
+    pools = {}
+    per_draw_b = []
+    for s in scored:
+        key = s["fkey"]
+        if key not in pools:
+            pools[key] = filtered_pool(s["filter"], lo, hi, k)
+        per_draw_b.append(hit_pmf_from_pool(pools[key], actual_by_date[s["date"]], k))
+
+    results = {}
+    for label, per_draw in [("A  unconstrained uniform", per_draw_a),
+                            ("B  same sum filter      ", per_draw_b)]:
+        exp_mean, sim = run_null(scored, per_draw, k, label)
+        p = (np.sum(sim >= obs_best) + 1) / (N_SIMS + 1)
+        exp_tiers = tier_expectation(scored, per_draw, k)
+        print(f"\nNULL {label}")
+        print(f"    expected mean best-of-N      : {exp_mean:.4f}   "
+              f"(sim sd {sim.std():.4f})")
+        print(f"    observed - expected          : {obs_best - exp_mean:+.4f}")
+        print(f"    one-sided p                  : {p:.4f}"
+              + ("   <-- significant at 0.05" if p < 0.05 else ""))
+        print(f"    expected prize tiers         : "
+              + ", ".join(f"match-{h}: {exp_tiers[h]:.2f}" for h in range(k, 2, -1)))
+        results[label.strip()] = p
+
+    print(f"\nVERDICT: ", end="")
+    pa, pb = results["A  unconstrained uniform"], results["B  same sum filter"]
+    if pb < 0.05:
+        print("survives the sum-filtered null - worth investigating further.")
+    elif pa < 0.05:
+        print("significant ONLY against unconstrained tickets. The apparent edge\n"
+              "         is the sum filter placing tickets in a denser region, not\n"
+              "         predictive skill. It buys no additional prize probability.")
+    else:
+        print("indistinguishable from chance under both nulls.")
+    return results
+
+
+if __name__ == "__main__":
+    for g in (sys.argv[1:] or ["NJ_Cash5"]):
+        analyse(g)

--- a/experiments/ledger_vs_random.py
+++ b/experiments/ledger_vs_random.py
@@ -52,23 +52,23 @@ def git_add_time(path):
     return pd.to_datetime(out) if out else None
 
 
-def is_provably_prior(path, draw_date):
+def is_provably_prior(path, draw_date, cutoff_hour=20):
     """
-    True if the file was committed before its draw could have happened.
+    True if the file was committed before its draw could possibly have happened.
 
-    Draws are in the evening; anything committed on or before the draw date is
-    prior to the draw. A file committed after its named date cannot be trusted
-    as out-of-sample and is dropped.
+    All five games draw in the evening (the earliest is ~21:00 ET), so a commit
+    landing before 20:00 ET on the draw date is unambiguously pre-draw. Using a
+    whole-day comparison would admit a file committed at 23:50 on draw day,
+    which is *after* a 22:57 draw -- that gap is the whole point of the check,
+    so the comparison is on timestamps, not dates.
     """
     t = git_add_time(path)
     if t is None:
         return False
-    return t.tz_localize(None).normalize() <= pd.Timestamp(draw_date).normalize()
+    t = t.tz_convert("America/New_York").tz_localize(None)
+    return t < pd.Timestamp(draw_date) + pd.Timedelta(hours=cutoff_hour)
 
 
-# ------------------------------------------------------------
-# Scoring
-# ------------------------------------------------------------
 def _random_subsets(m, lo, hi, k):
     """m uniform k-subsets of [lo, hi], vectorised."""
     pool_n = hi - lo + 1

--- a/lib/data/io.py
+++ b/lib/data/io.py
@@ -1,14 +1,42 @@
 # lib/data/io.py
 
 import glob
+import json
 import os
 import pandas as pd
 
 
-def load_data(gamedir: str) -> pd.DataFrame:
+def _matrix_start(gamedir: str, config: dict | None):
+    """
+    Return the game's `matrix_start` cutoff as a Timestamp, or None.
+
+    Lottery games periodically change their ball matrix (NJ Cash 5 has run as
+    5/38, 5/40, 5/43 and now 5/45). Draws from an earlier matrix are samples
+    from a *different distribution*: high balls look artificially cold because
+    they were impossible, and the sum statistics that drive the prediction
+    filter are centred on the wrong value. `matrix_start` truncates history to
+    the first draw of the current matrix.
+    """
+    if config is None:
+        cfg_path = os.path.join(gamedir, "config", "config.json")
+        if not os.path.exists(cfg_path):
+            return None
+        with open(cfg_path) as fh:
+            config = json.load(fh)
+
+    raw = config.get("matrix_start")
+    return pd.to_datetime(raw) if raw else None
+
+
+def load_data(gamedir: str, config: dict | None = None) -> pd.DataFrame:
     """
     Load all CSV files from gamedir/source/, enforce deterministic ordering,
     validate schema consistency, and return a clean DataFrame.
+
+    If the game config defines `matrix_start`, draws from before that date are
+    dropped so the model only ever sees the current ball matrix. Exact
+    duplicate rows are also removed. `config` is read from the game directory
+    when not supplied.
     """
 
     source_dir = os.path.join(gamedir, "source")
@@ -52,4 +80,23 @@ def load_data(gamedir: str) -> pd.DataFrame:
     if after < before:
         print(f"[load_data] Dropped {before - after} rows due to invalid numeric ball values")
 
-    return data
+    # Exact duplicate draws (same date, same numbers) are source-data errors.
+    # They double-count in every frequency feature, so drop them.
+    before = len(data)
+    data = data.drop_duplicates()
+    if len(data) < before:
+        print(f"[load_data] Dropped {before - len(data)} exact duplicate rows")
+
+    # Truncate to the current ball matrix, if the game declares one.
+    cutoff = _matrix_start(gamedir, config)
+    if cutoff is not None:
+        parsed = pd.to_datetime(data["Date"], format="mixed")
+        before = len(data)
+        data = data[parsed >= cutoff]
+        if len(data) < before:
+            print(
+                f"[load_data] Dropped {before - len(data)} rows from before "
+                f"matrix_start={cutoff.date()} (previous ball matrix)"
+            )
+
+    return data.reset_index(drop=True)

--- a/lib/models/accuracy.py
+++ b/lib/models/accuracy.py
@@ -134,6 +134,13 @@ def report_live_accuracy(gamedir, log, config, df, pred_file):
     with open(pred_file) as f:
         predictions = json.load(f)
 
+    # Unpopularity-mode files select for expected payout, not for hitting the
+    # draw. They make no predictive claim, so scoring them here would mix two
+    # different generation processes into one accuracy series.
+    if any(p.get("method") == "unpopularity" for p in predictions):
+        log.info(f"{date_str}: unpopularity-mode predictions, not scored for accuracy.")
+        return None
+
     best_match = max(
         (_count_hits(run.get("predicted", []), actual) for run in predictions),
         default=0

--- a/lib/models/unpopularity.py
+++ b/lib/models/unpopularity.py
@@ -1,0 +1,158 @@
+"""
+Ticket selection that maximises expected payout, not probability of winning.
+
+This module cannot improve your odds. For NJ Cash 5 they are 1 in 1,221,759
+per ticket, and nothing here changes that number. What it changes is how much
+you collect *if* you win.
+
+Every Jersey Cash 5 prize is pari-mutuel: a tier's pool is split among the
+tickets that reach it, so a jackpot won by two people pays each of them half.
+Human number choice is famously non-uniform -- calendar dates dominate, which
+massively over-plays 1-31 and especially 1-12; consecutive runs, arithmetic
+patterns, straight lines on the play slip and previously-drawn combinations
+all attract far more play than chance. Picking a combination other people
+avoid does not make it more likely to come up, it just means fewer people to
+split with when it does.
+
+Sizing, from FY2025 sales of $176M over 365 draws at $2 per play:
+
+    ~241,000 tickets per draw / 1,221,759 combinations = 0.197 expected
+    jackpot winners per draw at uniform play. Expected share of a jackpot is
+    E[1/(1+K)] for K ~ Poisson(lambda), so at a $1.96M jackpot:
+
+        all balls <= 31 (birthday combo)   68.0% return per $2 staked
+        average ticket                     79.6%
+        2+ balls > 31, no patterns         83.2%
+
+That is a 1.22x improvement in expected return, worth about $0.30 on a $2
+ticket. It is still a losing bet -- 83% is not 100% -- and it is a variance
+reduction in what you collect, not an edge on what gets drawn.
+
+Deliberately does NOT use the trained models. Across 445 leak-proof live draws
+the ensemble is indistinguishable from chance (pooled Stouffer Z = -0.33,
+p = 0.63; see experiments/ledger_vs_random.py), and a chi-squared test over
+NJ Cash 5's current matrix finds ball frequencies uniform (chi2 = 38.62,
+p = 0.70). Sampling uniformly and selecting for unpopularity is therefore both
+simpler and strictly better than re-ranking model output, which would inherit
+the sum filter -- and the sum filter is actively EV-negative, because sums near
+the mean are exactly where human pickers cluster.
+"""
+
+import numpy as np
+
+# Weights are ordered by the strength of the evidence behind each effect.
+# Calendar bias is by far the best-documented and gets the largest weight.
+DEFAULT_WEIGHTS = {
+    "above_calendar": 3.0,   # balls > 31 cannot be a day-of-month
+    "above_twelve": 1.0,     # balls > 12 cannot be a month
+    "no_consecutive": 1.5,   # consecutive pairs are over-played
+    "no_arithmetic": 1.0,    # evenly-spaced picks (5,10,15,20,25) are over-played
+    "sum_extremity": 1.0,    # mid-range sums are the crowded region
+    "spread": 0.5,           # clustered picks mirror play-slip geometry
+    "not_a_past_draw": 2.0,  # previously-drawn combinations get replayed
+    "few_single_digits": 1.0,  # single digits are over-played beyond calendar bias
+}
+
+
+def _consecutive_pairs(t):
+    s = np.sort(t)
+    return int(np.sum(np.diff(s) == 1))
+
+
+def _arithmetic_runs(t):
+    """Count 3-term evenly-spaced runs, e.g. 5-10-15 within the ticket."""
+    s = np.sort(t)
+    d = np.diff(s)
+    return int(np.sum(d[:-1] == d[1:]))
+
+
+def score_ticket(ticket, config, past_draws=None, weights=None):
+    """
+    Unpopularity score in [0, 1]; higher means fewer people share your prize.
+
+    `past_draws` is a set of sorted tuples of previously-drawn combinations.
+    """
+    w = {**DEFAULT_WEIGHTS, **(weights or {})}
+    t = np.asarray(ticket, dtype=int)
+    k = len(t)
+    lo, hi = config["ball_game_range_low"], config["ball_game_range_high"]
+
+    parts = {}
+
+    # Calendar bias: the single largest effect. Day-of-month picks cap at 31,
+    # month picks cap at 12.
+    parts["above_calendar"] = min(np.sum(t > 31), 2) / 2.0 if hi > 31 else 1.0
+    parts["above_twelve"] = min(np.sum(t > 12), 3) / 3.0 if hi > 12 else 1.0
+
+    # Ball 1 and other single digits carry extra popularity beyond the calendar
+    # effect (lucky numbers, top-left of the play slip).
+    parts["few_single_digits"] = 1.0 - min(np.sum(t < 10), 2) / 2.0
+
+    parts["no_consecutive"] = 1.0 if _consecutive_pairs(t) == 0 else 0.0
+    parts["no_arithmetic"] = 1.0 if _arithmetic_runs(t) == 0 else 0.0
+
+    # Sum extremity: distance from the centre of the sum distribution, scaled
+    # so a ticket one sd out scores ~1. Human picks cluster at the centre.
+    centre = k * (lo + hi) / 2.0
+    sd = np.sqrt(k * ((hi - lo + 1) ** 2 - 1) / 12.0 * (1 - (k - 1) / (hi - lo)))
+    parts["sum_extremity"] = min(abs(t.sum() - centre) / max(sd, 1e-9), 1.0)
+
+    # Spread: tightly bunched tickets echo play-slip geometry (a column or a
+    # block of adjacent numbers). Saturates at 60% of the range -- the aim is
+    # to rule out clusters, not to force 1 and 45 into every ticket, which
+    # would make all selected tickets near-identical and drag in ball 1, one
+    # of the most heavily played numbers there is.
+    parts["spread"] = min((t.max() - t.min()) / (0.6 * (hi - lo)), 1.0)
+
+    parts["not_a_past_draw"] = (
+        0.0 if past_draws and tuple(np.sort(t)) in past_draws else 1.0
+    )
+
+    total_w = sum(w[key] for key in parts)
+    return float(sum(w[key] * v for key, v in parts.items()) / total_w), parts
+
+
+def past_draw_set(data, config):
+    """Set of sorted tuples of every combination already drawn in `data`."""
+    cols = [f"Ball{i}" for i in config["game_balls"]]
+    return {tuple(sorted(int(v) for v in row)) for row in data[cols].to_numpy()}
+
+
+def generate_unpopular_tickets(config, n_tickets, past_draws=None,
+                               candidates=200_000, rng=None, weights=None,
+                               beta=12.0):
+    """
+    Sample `candidates` tickets uniformly, return `n_tickets` unpopular ones.
+
+    Uniform sampling is the point: every combination is equally likely to be
+    drawn, so restricting the candidate pool would only forfeit coverage. The
+    selection step never changes which combinations *can* win, only which of
+    the equally-likely ones we buy.
+
+    Selection is stochastic -- weighted by score**beta -- rather than a strict
+    top-N. Taking the argmax returns near-duplicate tickets that share most of
+    their balls, which concentrates the whole batch on one region of ticket
+    space and forfeits lower-tier coverage. Sampling keeps the batch diverse
+    while still drawing overwhelmingly from the unpopular tail.
+    """
+    rng = rng or np.random.default_rng()
+    lo, hi = config["ball_game_range_low"], config["ball_game_range_high"]
+    k = len(config["game_balls"])
+
+    pool = np.argsort(rng.random((candidates, hi - lo + 1)), axis=1)[:, :k] + lo
+    scores = np.array([score_ticket(t, config, past_draws, weights)[0] for t in pool])
+
+    w = scores ** beta
+    w = w / w.sum()
+    picked, seen = [], set()
+    for idx in rng.choice(len(pool), size=min(len(pool), n_tickets * 50),
+                          replace=False, p=w):
+        t = sorted(int(v) for v in pool[idx])
+        key = tuple(t)
+        if key in seen:
+            continue
+        seen.add(key)
+        picked.append((float(scores[idx]), t))
+        if len(picked) == n_tickets:
+            break
+    return picked

--- a/lottery.py
+++ b/lottery.py
@@ -20,6 +20,7 @@ from lib.data.features import engineer_features
 from lib.data.fetch import fetch_new_draws
 from lib.data.github import GitHubAutoMerge
 from lib.data.io import load_data
+from lib.models.unpopularity import generate_unpopular_tickets, past_draw_set
 from lib.data.normalize import normalize_features
 from lib.data.schedule import next_draw_dates, prediction_start_date
 from lib.models.accuracy import report_live_accuracy_all, evaluate_model_accuracy
@@ -105,6 +106,12 @@ def run_lottery(gamedir, args):
             run_automerge()
         return
 
+    if args.unpopular:
+        run_unpopular(gamedir, config, data, log, target_dates, args)
+        if args.automerge and not args.dry_run:
+            run_automerge()
+        return
+
     log.info("Engineering features (including entropy + regime)...")
     data = engineer_features(data, config, log)
 
@@ -141,6 +148,53 @@ def run_lottery(gamedir, args):
 
 
 # ------------------------------------------------------------
+# Unpopularity mode: maximise expected payout, not hit probability
+# ------------------------------------------------------------
+def run_unpopular(gamedir, config, data, log, target_dates, args):
+    """
+    Emit tickets chosen for how few people share them, not for what they are.
+
+    Deliberately skips the models. Across 445 leak-proof live draws the
+    ensemble is indistinguishable from chance, so uniform sampling loses
+    nothing, and the sum filter it would otherwise inherit is EV-negative --
+    mid-range sums are where human pickers cluster.
+    """
+    n_runs = config.get("test_prediction_runs", 10)
+    past = past_draw_set(data, config)
+    log.info(f"Unpopularity mode: sampling uniformly, selecting against "
+             f"{len(past)} previously-drawn combinations.")
+    log.info("This does NOT change the odds of winning, only the expected "
+             "share of a pari-mutuel prize.")
+
+    for target_date in target_dates:
+        tickets = generate_unpopular_tickets(config, n_runs, past_draws=past)
+        predictions = [
+            {
+                "run": i + 1,
+                "date": target_date,
+                "predicted": t,
+                "unpopularity_score": round(score, 4),
+                "predicted_sum": sum(t),
+                "method": "unpopularity",
+                "config": {
+                    "game_balls": config["game_balls"],
+                    "game_has_extra": config.get("game_has_extra", False),
+                },
+            }
+            for i, (score, t) in enumerate(tickets)
+        ]
+        for p in predictions:
+            log.info(f"[Run {p['run']}] score={p['unpopularity_score']:.3f} "
+                     f"sum={p['predicted_sum']:3d} {p['predicted']}")
+
+        if args.dry_run:
+            log.info("Dry run enabled - not exporting predictions.")
+            continue
+        log.info(f"Exporting predictions for {target_date}...")
+        export_predictions(predictions, gamedir, log, date_str=target_date)
+
+
+# ------------------------------------------------------------
 # CLI
 # ------------------------------------------------------------
 def main():
@@ -163,6 +217,10 @@ def main():
                         help="Number of upcoming draw dates to predict (one prediction file per draw date)")
     parser.add_argument("--update-data", action="store_true",
                         help="Fetch the latest winning numbers from the NJ Lottery API and append to source CSV")
+    parser.add_argument("--unpopular", action="store_true",
+                        help="Select tickets for expected payout instead of predicted numbers: sample uniformly "
+                             "and keep combinations other players avoid. Does not change the odds of winning; "
+                             "raises the expected share of a pari-mutuel prize. Bypasses model training.")
 
     args = parser.parse_args()
     run_lottery(args.gamedir, args)

--- a/tests/test_io_matrix.py
+++ b/tests/test_io_matrix.py
@@ -1,0 +1,89 @@
+"""Tests for load_data's matrix-era truncation and duplicate removal."""
+
+import json
+import os
+
+import pandas as pd
+import pytest
+
+from lib.data.io import load_data
+
+
+def _make_game(tmp_path, rows, config=None):
+    """Write a minimal game directory with one source CSV and optional config."""
+    gamedir = tmp_path / "TestGame"
+    (gamedir / "source").mkdir(parents=True)
+    pd.DataFrame(rows, columns=["Date", "Ball1", "Ball2", "Ball3"]).to_csv(
+        gamedir / "source" / "draws.csv", index=False
+    )
+    if config is not None:
+        (gamedir / "config").mkdir()
+        (gamedir / "config" / "config.json").write_text(json.dumps(config))
+    return str(gamedir)
+
+
+ROWS = [
+    ["01/01/2019", 1, 2, 3],   # old matrix
+    ["06/15/2020", 4, 5, 6],   # old matrix
+    ["06/29/2020", 7, 8, 9],   # first draw of current matrix
+    ["07/01/2020", 10, 11, 12],
+]
+
+
+def test_matrix_start_drops_previous_matrix(tmp_path):
+    gamedir = _make_game(tmp_path, ROWS, {"matrix_start": "2020-06-29"})
+    data = load_data(gamedir)
+    assert len(data) == 2
+    assert data["Date"].tolist() == ["06/29/2020", "07/01/2020"]
+    # index is reset so downstream positional logic stays valid
+    assert data.index.tolist() == [0, 1]
+
+
+def test_matrix_start_is_inclusive_of_the_cutoff_date(tmp_path):
+    gamedir = _make_game(tmp_path, ROWS, {"matrix_start": "2020-06-29"})
+    assert "06/29/2020" in load_data(gamedir)["Date"].tolist()
+
+
+def test_no_matrix_start_keeps_all_rows(tmp_path):
+    gamedir = _make_game(tmp_path, ROWS, {"ball_game_range_low": 1})
+    assert len(load_data(gamedir)) == len(ROWS)
+
+
+def test_missing_config_file_keeps_all_rows(tmp_path):
+    gamedir = _make_game(tmp_path, ROWS, config=None)
+    assert len(load_data(gamedir)) == len(ROWS)
+
+
+def test_explicit_config_argument_overrides_config_file(tmp_path):
+    gamedir = _make_game(tmp_path, ROWS, {"matrix_start": "2020-06-29"})
+    data = load_data(gamedir, config={"matrix_start": "2019-01-01"})
+    assert len(data) == len(ROWS)
+
+
+def test_exact_duplicate_rows_are_dropped(tmp_path):
+    rows = ROWS + [["07/01/2020", 10, 11, 12]]  # exact repeat of the last draw
+    gamedir = _make_game(tmp_path, rows, {"matrix_start": "2020-06-29"})
+    assert len(load_data(gamedir)) == 2
+
+
+def test_same_date_different_numbers_is_kept(tmp_path):
+    """Multi-draw games legitimately have two different draws on one date."""
+    rows = ROWS + [["07/01/2020", 13, 14, 15]]
+    gamedir = _make_game(tmp_path, rows, {"matrix_start": "2020-06-29"})
+    assert len(load_data(gamedir)) == 3
+
+
+@pytest.mark.parametrize(
+    "gamedir,expected_high",
+    [("NJ_Cash5", 45), ("NJ_Pick6", 46), ("Powerball", 69), ("Megamillions", 70)],
+)
+def test_real_games_contain_only_current_matrix_balls(gamedir, expected_high):
+    """Regression guard: no shipped game may train on a previous ball matrix."""
+    if not os.path.isdir(gamedir):
+        pytest.skip(f"{gamedir} not present")
+    config = json.load(open(os.path.join(gamedir, "config", "config.json")))
+    data = load_data(gamedir)
+    main_cols = [f"Ball{i}" for i in config["game_balls"]]
+    assert data[main_cols].to_numpy().max() <= expected_high
+    assert data[main_cols].to_numpy().min() >= config["ball_game_range_low"]
+    assert config["ball_game_range_high"] == expected_high

--- a/tests/test_unpopularity.py
+++ b/tests/test_unpopularity.py
@@ -99,3 +99,38 @@ def test_selection_never_restricts_the_reachable_ball_range():
     )
     used = {b for _, t in tickets for b in t}
     assert min(used) <= 12 and max(used) == 45
+
+
+def test_unpopularity_files_are_excluded_from_live_accuracy(tmp_path, caplog):
+    """These tickets make no predictive claim; scoring them would corrupt the
+    model's accuracy series."""
+    import json
+    import logging
+
+    from lib.models.accuracy import report_live_accuracy
+
+    pred = tmp_path / "2026-08-22.json"
+    pred.write_text(json.dumps([
+        {"run": 1, "date": "2026-08-22", "predicted": [1, 2, 3, 4, 5],
+         "method": "unpopularity"}
+    ]))
+    df = pd.DataFrame([["2026-08-22", 1, 2, 3, 4, 5]],
+                      columns=["Date"] + [f"Ball{i}" for i in range(1, 6)])
+    log = logging.getLogger("t")
+
+    # A perfect match would otherwise score 5/5.
+    assert report_live_accuracy(str(tmp_path), log, CONFIG, df, str(pred)) is None
+
+
+def test_model_prediction_files_are_still_scored(tmp_path):
+    import json
+    import logging
+
+    from lib.models.accuracy import report_live_accuracy
+
+    pred = tmp_path / "2026-08-22.json"
+    pred.write_text(json.dumps([{"run": 1, "predicted": [1, 2, 3, 9, 10]}]))
+    df = pd.DataFrame([["2026-08-22", 1, 2, 3, 4, 5]],
+                      columns=["Date"] + [f"Ball{i}" for i in range(1, 6)])
+    result = report_live_accuracy(str(tmp_path), logging.getLogger("t"), CONFIG, df, str(pred))
+    assert result == ("2026-08-22", 3, 5)

--- a/tests/test_unpopularity.py
+++ b/tests/test_unpopularity.py
@@ -1,0 +1,101 @@
+"""Tests for expected-payout ticket selection."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from lib.models.unpopularity import (
+    generate_unpopular_tickets,
+    past_draw_set,
+    score_ticket,
+)
+
+CONFIG = {"ball_game_range_low": 1, "ball_game_range_high": 45,
+          "game_balls": [1, 2, 3, 4, 5]}
+
+
+def s(ticket, past=None):
+    return score_ticket(ticket, CONFIG, past or set())[0]
+
+
+def test_score_is_bounded():
+    for t in ([1, 2, 3, 4, 5], [2, 17, 29, 38, 44], [41, 42, 43, 44, 45]):
+        assert 0.0 <= s(t) <= 1.0
+
+
+def test_birthday_combination_scores_below_a_high_ball_combination():
+    """All balls <= 31 is the single most over-played shape."""
+    assert s([3, 11, 19, 24, 28]) < s([3, 11, 19, 38, 44])
+
+
+def test_consecutive_runs_are_penalised():
+    assert s([4, 5, 18, 33, 41]) < s([4, 9, 18, 33, 41])
+
+
+def test_arithmetic_progressions_are_penalised():
+    """5-15-25-35-45 is evenly spaced; the comparison ticket has no 3-term run.
+    Both hold two balls above 31 and one single digit, so only the
+    progression term differs."""
+    assert s([5, 15, 25, 35, 45]) < s([5, 16, 26, 35, 45])
+
+
+def test_previously_drawn_combination_is_penalised():
+    ticket = [2, 17, 29, 38, 44]
+    assert s(ticket, past={(2, 17, 29, 38, 44)}) < s(ticket, past=set())
+
+
+def test_past_draw_lookup_is_order_independent():
+    past = {(2, 17, 29, 38, 44)}
+    assert s([44, 2, 38, 17, 29], past=past) == s([2, 17, 29, 38, 44], past=past)
+
+
+def test_past_draw_set_from_dataframe():
+    df = pd.DataFrame([[5, 3, 1, 4, 2]], columns=[f"Ball{i}" for i in range(1, 6)])
+    assert past_draw_set(df, CONFIG) == {(1, 2, 3, 4, 5)}
+
+
+def test_generate_returns_valid_distinct_tickets():
+    tickets = generate_unpopular_tickets(
+        CONFIG, 10, past_draws=set(), candidates=20000,
+        rng=np.random.default_rng(0),
+    )
+    assert len(tickets) == 10
+    seen = set()
+    for score, t in tickets:
+        assert len(t) == 5 and len(set(t)) == 5
+        assert all(1 <= b <= 45 for b in t)
+        assert t == sorted(t)
+        assert tuple(t) not in seen
+        seen.add(tuple(t))
+
+
+def test_generated_tickets_favour_balls_above_the_calendar_range():
+    """The whole point: over-weight the numbers birthdays cannot reach."""
+    tickets = generate_unpopular_tickets(
+        CONFIG, 20, past_draws=set(), candidates=40000,
+        rng=np.random.default_rng(1),
+    )
+    balls = [b for _, t in tickets for b in t]
+    frac_high = sum(b > 31 for b in balls) / len(balls)
+    assert frac_high > 14 / 45  # chance rate for balls 32-45
+
+
+def test_generated_tickets_are_not_near_duplicates():
+    """Strict top-N selection used to return tickets sharing 4 of 5 balls."""
+    tickets = generate_unpopular_tickets(
+        CONFIG, 10, past_draws=set(), candidates=40000,
+        rng=np.random.default_rng(2),
+    )
+    for i, (_, a) in enumerate(tickets):
+        for _, b in tickets[i + 1:]:
+            assert len(set(a) & set(b)) <= 3
+
+
+def test_selection_never_restricts_the_reachable_ball_range():
+    """Every ball must remain reachable -- restricting coverage forfeits wins."""
+    tickets = generate_unpopular_tickets(
+        CONFIG, 200, past_draws=set(), candidates=60000,
+        rng=np.random.default_rng(3),
+    )
+    used = {b for _, t in tickets for b in t}
+    assert min(used) <= 12 and max(used) == 45


### PR DESCRIPTION
Three commits. The first is a data-correctness bug; the second measures whether the model works; the third acts on the answer.

## 1. Training data mixes multiple ball matrices

Every game except `NJ_Millionaire4Life` has changed its ball matrix at least once, and the source CSVs stack all eras into one file. Nothing in the pipeline was matrix-aware. Draws from an earlier matrix are samples from a *different distribution*.

**Frequency features treat formerly-impossible balls as cold.** Expected per-ball frequency in NJ Cash 5 is 1/45 = 0.02222:

| ball | full history | 5/45 era | distortion |
|---|---|---|---|
| 20 | 0.02413 | 0.02033 | 1.19x |
| 41 | 0.00956 | 0.02104 | 0.45x |
| 44 | 0.00435 | 0.02024 | **0.21x** |
| 45 | 0.00544 | 0.02532 | **0.21x** |

This propagates into `global_freq`, per-ball freq, decaying freq, gap tracking, zone counts, positional freq and draw spread.

**The sum filter excluded the game's own mean.** `prepare_statistics` computed `mean_sum = 105.95` from the mixed history; the current game's mean is 114.22 (theoretical 115.0). With `mean_allowance: 0.05`, `predictor.py:857` only accepted sums in **[100.7, 111.2]** — so every ticket was pushed into a low-sum region. The 2026-08-22 file confirms it: all ten sums fall in 103–111.

**NJ Pick 6 was affected differently, and worse.** `features.py:14` silently *drops* rows with any ball outside the config range. After the 2022 6/49 → 6/46 change the survivors were a **biased low-number subsample** — 3,487 of 3,924 training rows were 6/49-era draws that happened to have all six balls ≤ 46. Training `mean_sum` 138.70 against the true 143.17.

Fix: optional `matrix_start` config field; `load_data` truncates to it and drops exact duplicate rows.

| game | matrix_start | matrix | rows |
|---|---|---|---|
| NJ_Cash5 | 2020-06-29 | 5/45 (was 5/38, 5/40, 5/43) | 10437 → 2238 |
| NJ_Pick6 | 2022-04-07 | 6/46 (was 6/36…6/49) | 4706 → 513 |
| Powerball | 2015-10-07 | 5/69 + 1/26 | 3267 → 1396 |
| Megamillions | 2017-10-31 | 5/70 + 1/25 | 3053 → 920 |

Cutoffs verified against the data, not only external sources — the last out-of-range draw and the first in-range draw bracket each date (Pick 6: last ball >46 on 2022-04-04, first draw after cutoff 2022-04-11). NJ's press material independently confirms the Cash 5 date as 2020-06-29. Also removes 151 duplicate rows in NJ_Pick6 and 7 in NJ_Cash5.

All four games now produce a ±5% sum band containing their theoretical mean.

This discards a lot of data — Pick 6 drops to 513 rows and shows small-sample warnings during training. Correct-and-thin beats plentiful-and-wrong: the discarded rows came from a different game.

## 2. Does the model beat chance? No.

`experiments/ledger_vs_random.py` scores the live ledger. Prediction files are admitted only when their git add-time precedes the draw they name, checked on timestamps against a 20:00 ET cutoff (earlier than any of the five games' draw times) — a date-only comparison would admit a file committed at 23:50 on draw day, after a 22:57 draw. 129 of 585 files were committed after their draw, nearly all from a Feb–Apr 2026 backfill; they are dropped.

Two nulls, because the pipeline only emits sum-filtered tickets and those sit in a denser region of ticket space — which raises average balls-matched without raising the probability of any prize. Null A is unconstrained uniform; null B applies the identical mean/mode/stddev filter, reconstructed per file from the stats each prediction recorded. Both use the exact best-of-N distribution `F_best(h) = F(h)**N` rather than nested simulation. Prize tiers are reported alongside balls-matched, since tiers cannot be nudged by ticket placement.

| game | draws | observed | expected | p (null B) | BH q |
|---|---|---|---|---|---|
| NJ_Cash5 | 177 | 1.559 | 1.666 | 0.994 | 0.994 |
| NJ_Pick6 | 32 | 1.906 | 2.099 | 0.971 | 0.994 |
| Powerball | 75 | 1.307 | 1.264 | 0.283 | 0.471 |
| Megamillions | 49 | 1.429 | 1.297 | 0.059 | 0.148 |
| NJ_Millionaire4Life | 112 | 1.598 | 1.487 | 0.024 | 0.118 |

**Pooled Stouffer Z = −0.326, p = 0.63.** Nothing survives multiple-comparisons correction. Zero match-4 or match-5 tickets across 4,553 tickets.

`experiments/hypothesis_tests.py NJ_Cash5` on the corrected data agrees: sum autocorrelation Ljung-Box p = 0.34, hot/cold odds ratios 1.01–1.05 (ns), and ball frequencies uniform at **χ² = 38.62, p = 0.70**. (The per-position "NON-UNIFORM" flags in that report are an artifact of sorted order statistics — the minimum of five draws must skew low — not evidence of bias.)

## 3. `hot_hand_or` → 1.0

`NJ_Cash5` boosted recently-drawn balls by 10.9% at sampling time and `NJ_Pick6` by 3.9%. Both were fitted to the pre-truncation data; re-measured on the current matrix neither effect is significant (p = 0.20, p = 0.14). Set to 1.0.

## 4. `--unpopular`: optimise expected payout instead

Given the above, the remaining lever is what you collect if you win, not the chance of winning. Every Jersey Cash 5 prize is pari-mutuel — a jackpot won by two people pays each half — and human picks are heavily non-uniform.

From FY2025 sales of $176M over 365 draws at $2/play: ~241,000 tickets against 1,221,759 combinations = 0.197 expected jackpot winners. Expected share is `E[1/(1+K)]`, `K ~ Poisson(λ)`. At a $1.96M jackpot:

| ticket type | expected return per $2 |
|---|---|
| all balls ≤ 31 (birthday combo) | 68.0% |
| average ticket | 79.6% |
| 2+ balls > 31, no patterns | **83.2%** |

**1.22× expected return, ~$0.30 on a $2 ticket.** It is still a losing bet, and **the odds of winning are unchanged at 1 in 1,221,759.**

`lib/models/unpopularity.py` bypasses the models rather than re-ranking their output — re-ranking would inherit the sum filter, and that filter is EV-*negative* because mid-range sums are where human pickers cluster. Selection is stochastic (`score**beta`) rather than strict top-N: argmax selection returned near-duplicate tickets sharing four of five balls, concentrating the batch and forfeiting lower-tier coverage. That regression is pinned by `test_generated_tickets_are_not_near_duplicates`.

## Checks

- `pipenv run pytest` — 114 passed, 91% coverage (`io.py` 92%, `unpopularity.py` 98%)
- `python lottery.py NJ_Pick6 --dry-run --force-retrain` — clean
- `python lottery.py NJ_Cash5 --dry-run --force-retrain` — clean; sums now spread 109–115 instead of pinning to 103–111
- `python lottery.py NJ_Cash5 --unpopular --dry-run --force-retrain` — clean
- New: `tests/test_io_matrix.py` (11), `tests/test_unpopularity.py` (13), including a guard that no shipped game trains on a previous ball matrix

`--unpopular` writes to the same `predictions/<date>.json` path the accuracy tooling reads, so both `report_live_accuracy` and the ledger script now skip files carrying `"method": "unpopularity"` — otherwise those tickets would silently join the model's accuracy series.

## Note

Items 1 and 3 make the pipeline correct; they do not make it predictive. Item 4 is the only change that improves an outcome, and it improves payout, not odds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

